### PR TITLE
Fix ruff lint issues in Python code

### DIFF
--- a/src/cpulist.py
+++ b/src/cpulist.py
@@ -60,13 +60,17 @@ You can use this to discover the specification of a remote system:
 
 from __future__ import print_function
 
-import platform, sys, os, itertools, re
+import itertools
+import os
+import platform
+import re
+import sys
 
 o_verbose = 0
 
 
 try:
-    from pyperf.perf_util import *
+    from pyperf.perf_util import list_cpusetstr
     check_cpusetstr = True
 except ImportError:
     def file_word(fn):

--- a/src/sysreport.py
+++ b/src/sysreport.py
@@ -33,7 +33,13 @@ Similar to lscpu, but
 
 from __future__ import print_function
 
-import os, sys, platform, subprocess, multiprocessing, json, datetime, struct
+import datetime
+import multiprocessing
+import os
+import platform
+import struct
+import subprocess
+import sys
 
 # import gzip for reading /proc/config.gz
 try:
@@ -42,11 +48,10 @@ except ImportError:
     pass
 
 import cpulist
-
 import strcolor
 from strcolor import colorize
 
-_is_arm = (platform.machine() in ["armv8l", "aarch64"])
+_is_arm = platform.machine() in ("armv8l", "aarch64")
 
 o_verbose = 0
 
@@ -214,7 +219,7 @@ def acpi_irqs():
         irqs = {}
         with open("/sys/firmware/acpi/tables/APIC", "rb") as f:
             f.read(4)          # signature (b"APIC")
-            hdr = f.read(32)   # general ACPI header
+            _hdr = f.read(32)   # general ACPI header
             f.read(8)          # APIC
             while True:
                 ih = f.read(2)
@@ -508,7 +513,9 @@ def pyperf_installed():
     """
     try:
         sys.path.append(os.path.join(os.path.dirname(__file__), "pyperf"))
-        import perf_enum, perf_attr, perf_events
+        import perf_attr
+        import perf_enum
+        import perf_events
     except ImportError:
         return None   # unknown
     try:


### PR DESCRIPTION
% `ruff check --output-format=concise ` # https://docs.astral.sh/ruff/linter
```
src/cpulist.py:63:1: E401 [*] Multiple imports on one line
src/cpulist.py:69:5: F403 `from pyperf.perf_util import *` used; unable to detect undefined names
src/cpulist.py:371:39: F405 `list_cpusetstr` may be undefined, or defined from star imports
src/cpulist.py:372:39: F405 `list_cpusetstr` may be undefined, or defined from star imports
src/sysreport.py:36:1: E401 [*] Multiple imports on one line
src/sysreport.py:36:56: F401 [*] `json` imported but unused
src/sysreport.py:217:13: F841 Local variable `hdr` is assigned to but never used
src/sysreport.py:511:9: E401 [*] Multiple imports on one line
Found 8 errors.
[*] 4 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
```